### PR TITLE
Clang compatibility. Ignore Darwin bins. Comment unused variables.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,12 @@
 *.o
 *.so
 
-linux64GccDPInt32Opt
+linux*Gcc*/
+linux*Icc*/
+darwin*Gcc*/
+darwin*Intel*/
+darwin*Arm*/
+darwin*Clang*/
 .vscode
 lnInclude
 log.*

--- a/applications/floatStepper/alphaSuSp.H
+++ b/applications/floatStepper/alphaSuSp.H
@@ -6,4 +6,4 @@
 \*---------------------------------------------------------------------------*/
 zeroField Su;
 zeroField Sp;
-zeroField divU;
+//zeroField divU;

--- a/applications/util/KirchhoffKelvinIntegrator2D/KirchhoffKelvinIntegrator2D.C
+++ b/applications/util/KirchhoffKelvinIntegrator2D/KirchhoffKelvinIntegrator2D.C
@@ -224,8 +224,8 @@ public:
 
         //domegadt = ((A(1)-A(2))*U(1)*U(2))/A(3);
 
-        scalar x = Y[0];
-        scalar y = Y[1];
+        // scalar x = Y[0];
+        // scalar y = Y[1];
         scalar th = Y[2];
         scalar v1 = Y[3];
         scalar v2 = Y[4];

--- a/applications/util/joukowskiTransformPoints/joukowskiTransformPoints.C
+++ b/applications/util/joukowskiTransformPoints/joukowskiTransformPoints.C
@@ -375,7 +375,7 @@ int main(int argc, char *argv[])
     }
     else if (args.readIfPresent("joukowski", a))
     {
-        scalarField aor2 = a*a/magSqr(points - points.component(vector::Z)*vector(0,0,1));
+        scalarField aor2(a*a/magSqr(points - points.component(vector::Z)*vector(0,0,1)));
         points.replace(vector::X, (1 + aor2)*points.component(vector::X));
         points.replace(vector::Y, (1 - aor2)*points.component(vector::Y));
     }

--- a/src/addedMass/pisoAddedMass/pisoAddedMass.C
+++ b/src/addedMass/pisoAddedMass/pisoAddedMass.C
@@ -179,7 +179,7 @@ void Foam::pisoAddedMass::calcPressureForceAndTorque
     for (int m = 0; m <= pimple.nCorrPISO(); m++)
     {
 
-        volScalarField rAU2 = 1.0/U2Eqn.A();
+        volScalarField rAU2(1.0/U2Eqn.A());
         surfaceScalarField rAU2f("rAU2f", fvc::interpolate(rAU2));
 
         volVectorField HbyA2(constrainHbyA(rAU2*U2Eqn.H(), U2, p_rgh2));

--- a/src/addedMass/slipVelocityFvPatchVectorField.C
+++ b/src/addedMass/slipVelocityFvPatchVectorField.C
@@ -129,7 +129,7 @@ void Foam::slipVelocityFvPatchVectorField::updateCoeffs
 
     curTimeIndex_ = this->db().time().timeIndex();
 
-    const vectorField nHat = this->patch().nf();
+    const vectorField nHat(this->patch().nf());
 
     vectorField::operator=
     (

--- a/src/floaterMotion/dynamicFloaterMotionSolversFvMesh/alphaSuSp.H
+++ b/src/floaterMotion/dynamicFloaterMotionSolversFvMesh/alphaSuSp.H
@@ -6,4 +6,4 @@
 \*---------------------------------------------------------------------------*/
 zeroField Su;
 zeroField Sp;
-zeroField divU;
+//zeroField divU;

--- a/src/floaterMotion/floaterMotionSolver/floaterMotionSolver.C
+++ b/src/floaterMotion/floaterMotionSolver/floaterMotionSolver.C
@@ -101,7 +101,7 @@ Foam::floaterMotionSolver::floaterMotionSolver
     di_(coeffDict().get<scalar>("innerDistance")),
     do_(coeffDict().get<scalar>("outerDistance")),
     distStretch_(coeffDict().getOrDefault<tensor>("distStretch", tensor::I)),
-    rhoInf_(1.0),
+    //rhoInf_(1.0),
     rhoName_(coeffDict().getOrDefault<word>("rho", "rho")),
     scale_
     (

--- a/src/floaterMotion/floaterMotionSolver/floaterMotionSolver.H
+++ b/src/floaterMotion/floaterMotionSolver/floaterMotionSolver.H
@@ -86,7 +86,7 @@ class floaterMotionSolver
 
         //- Reference density required by the forces object for
         //  incompressible calculations, required if rho == rhoInf
-        scalar rhoInf_;
+        //scalar rhoInf_;
 
         //- Name of density field, optional unless used for an
         //  incompressible simulation, when this needs to be specified

--- a/src/floaterMotion/fvPatchFields/floaterVelocity/floaterVelocityFvPatchVectorField.C
+++ b/src/floaterMotion/fvPatchFields/floaterVelocity/floaterVelocityFvPatchVectorField.C
@@ -212,7 +212,7 @@ void Foam::floaterVelocityFvPatchVectorField::updateCoeffs()
     if (slip_)
     {
         // Note: Using reference here causes crash
-        const vectorField nHat = this->patch().nf();
+        const vectorField nHat(this->patch().nf());
 
         vectorField::operator=
         (


### PR DESCRIPTION
Thanks, Johan and team, for this nice toolbox!

This pull request contains some minor changes:
- Changes to allow the code to compile with the Clang compiler (default on macOS but some also use it on Linux).
- Include Darwin (macOS) build directories in the gitignore (macOS).
- Comment out some unused variables.

By the way, can you point to cases (e.g., tutorials) where the default OpenFOAM.com 6DOF dynamic + interFoam fails (or performs poorly), while floatStepper succeeds? Sorry, I know your presentations likely answer this questions but I am lazy :D