### PR TITLE
BUGFIX: MoorDyn output writing slowing down the simulation

### DIFF
--- a/thirdParty/MoorDyn/src/moorDynR1/moorDynR1.C
+++ b/thirdParty/MoorDyn/src/moorDynR1/moorDynR1.C
@@ -112,6 +112,8 @@ void Foam::floaterMotionRestraints::moorDynR1::restrain
     vector& restraintMoment
 ) const
 {
+    if (Pstream::master())
+{
     scalar deltaT = motion.time().deltaTValue();
     scalar t = motion.time().value();
     scalar tprev = t - deltaT;
@@ -194,6 +196,12 @@ void Foam::floaterMotionRestraints::moorDynR1::restrain
         Info<< t << ": force " << restraintForce << ", moment "
             << restraintMoment << endl;
     }
+}
+
+        //Distribute results to other nodes:
+    Pstream::broadcast(restraintPosition);
+    Pstream::broadcast(restraintForce);
+    Pstream::broadcast(restraintMoment);
 }
 
 


### PR DESCRIPTION
This pull request includes updates to the code aimed at removing slowdowns associated with MoorDyn. Specifically, the changes ensure that output is now sent only from the main node, rather than from all nodes, thus improving performance. 